### PR TITLE
feat: report schema v4

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,6 @@ export default class LOLSDK {
 export type Report = {
   feedId:                  string
   observationsTimestamp:   bigint
-  benchmarkPrice:          bigint
 } & (
   {
     version:               'v1'
@@ -41,11 +40,15 @@ export type Report = {
     currentBlockHash:      string
     validFromBlockNum:     bigint
     currentBlockTimeStamp: bigint
+    benchmarkPrice:        bigint
+
   } | {
     version:               'v2'
     nativeFee:             bigint
     linkFee:               bigint
     expiresAt:             number
+    benchmarkPrice:        bigint
+    
   } | {
     version:               'v3'
     nativeFee:             bigint
@@ -53,5 +56,15 @@ export type Report = {
     expiresAt:             number
     bid:                   bigint
     ask:                   bigint
+    benchmarkPrice:        bigint
+    
+  } | {
+    version: 'v4'
+    validFromTimestamp:    bigint
+    nativeFee:             bigint
+    linkFee:               bigint
+    expiresAt:             number
+    price:                 bigint
+    marketStatus:          number
   }
 )

--- a/index.js
+++ b/index.js
@@ -350,6 +350,16 @@ export class Report {
       {name: "benchmarkPrice",        type: "int192"},
       {name: "bid",                   type: "int192"},
       {name: "ask",                   type: "int192"},
+    ],
+    v4: [
+      {name: "feedId",                type: "bytes32"},
+      {name: "validFromTimestamp",    type: "uint32"},
+      {name: "observationsTimestamp", type: "uint32"},
+      {name: "nativeFee",             type: "uint192"},
+      {name: "linkFee",               type: "uint192"},
+      {name: "expiresAt",             type: "uint32"},
+      {name: "price",                 type: "int192"},
+      {name: "marketStatus",          type: "uint32"},
     ]
   }
 
@@ -370,6 +380,7 @@ export class Report {
       case 1: return 'v1'
       case 2: return 'v2'
       case 3: return 'v3'
+      case 4: return 'v4'
       default: throw new Error(`Unsupported version ${version} from feed ID ${feedId}`)
     }
   }


### PR DESCRIPTION
This PR adds report schema v4 ([documentation ref](https://docs.chain.link/data-streams/reference/report-schema-v4):

| Field                 | Type     | Description |
|-----------------------|---------|------------|
| feedID               | bytes32  | The unique identifier for the stream |
| validFromTimestamp   | uint32   | The earliest timestamp during which the price is valid |
| observationsTimestamp | uint32   | The latest timestamp during which the price is valid |
| nativeFee           | uint192  | The cost to verify this report onchain when paying with the blockchain's native token |
| linkFee             | uint192  | The cost to verify this report onchain when paying with LINK |
| expiresAt           | uint32   | The expiration date of this report |
| price              | int192   | The DON's consensus median price for this report carried to 18 decimal places |
| marketStatus       | uint32   | The DON's consensus on whether the market is currently open. Possible values: 0 (Unknown), 1 (Closed), 2 (Open). |
